### PR TITLE
proposal: a new flow to dispose things

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity android:name=".koinIntegration.KoinIntegrationActivity"/>
         <activity android:name=".hiltIntegration.HiltMainActivity"/>
         <activity android:name=".androidLegacy.LegacyActivity"/>
+        <activity android:name=".transitions.TransitionNavigationActivity"/>
     </application>
 
 </manifest>

--- a/sample/src/main/java/cafe/adriel/voyager/sample/SampleActivity.kt
+++ b/sample/src/main/java/cafe/adriel/voyager/sample/SampleActivity.kt
@@ -30,6 +30,7 @@ import cafe.adriel.voyager.sample.rxJavaIntegration.RxJavaIntegrationActivity
 import cafe.adriel.voyager.sample.screenModel.ScreenModelActivity
 import cafe.adriel.voyager.sample.stateStack.StateStackActivity
 import cafe.adriel.voyager.sample.tabNavigation.TabNavigationActivity
+import cafe.adriel.voyager.sample.transitions.TransitionNavigationActivity
 
 class SampleActivity : ComponentActivity() {
 
@@ -62,6 +63,7 @@ class SampleActivity : ComponentActivity() {
                 StartSampleButton<LiveDataIntegrationActivity>("LiveData Integration")
                 StartSampleButton<HiltMainActivity>("Hilt Integration")
                 StartSampleButton<LegacyActivity>("Legacy Integration")
+                StartSampleButton<TransitionNavigationActivity>("Transition Integration")
             }
         }
     }

--- a/sample/src/main/java/cafe/adriel/voyager/sample/transitions/TransitionNavigationActivity.kt
+++ b/sample/src/main/java/cafe/adriel/voyager/sample/transitions/TransitionNavigationActivity.kt
@@ -1,0 +1,122 @@
+package cafe.adriel.voyager.sample.transitions
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.core.screen.uniqueScreenKey
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.transitions.FadeTransition
+
+class TransitionNavigationActivity : ComponentActivity() {
+
+    @ExperimentalAnimationApi
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            Navigator(ScreenFoo()) { navigator ->
+                Column(Modifier.fillMaxSize()) {
+                    var enabled by remember { mutableStateOf(true) }
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .weight(1f)
+                    ) {
+                        FadeTransition(
+                            navigator,
+                            animationSpec = spring(
+                                stiffness = Spring.StiffnessVeryLow,
+                                visibilityThreshold = null
+                            ),
+                            onTransitionEnd = {
+                                enabled = true
+                            }
+                        )
+                    }
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                    ) {
+                        Button(
+                            enabled = enabled,
+                            onClick = {
+                                navigator.replace(ScreenFoo())
+                                enabled = false
+                            }
+                        ) {
+                            Text(text = "to FooScreen")
+                        }
+                        Spacer(Modifier.size(16.dp))
+                        Button(
+                            enabled = enabled,
+                            onClick = {
+                                navigator.replace(ScreenBar())
+                                enabled = false
+                            }
+                        ) {
+                            Text(text = "to BarScreen")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+class ScreenFoo : Screen {
+    @Composable
+    override fun Content() {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color.DarkGray),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("ScreenFoo")
+        }
+    }
+}
+
+class ScreenBar : Screen {
+
+    override val key: ScreenKey
+        get() = uniqueScreenKey
+
+    @Composable
+    override fun Content() {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color.LightGray),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("ScreenBar")
+        }
+    }
+}

--- a/voyager-navigator/src/jvmMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
+++ b/voyager-navigator/src/jvmMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
@@ -5,10 +5,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.staticCompositionLocalOf
+import cafe.adriel.voyager.core.lifecycle.ScreenLifecycleStore
 import cafe.adriel.voyager.core.lifecycle.rememberScreenLifecycleOwner
+import cafe.adriel.voyager.core.model.ScreenModelStore
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.stack.Stack
 import cafe.adriel.voyager.core.stack.toMutableStateStack
@@ -16,6 +19,8 @@ import cafe.adriel.voyager.navigator.internal.LocalNavigatorStateHolder
 import cafe.adriel.voyager.navigator.internal.NavigatorBackHandler
 import cafe.adriel.voyager.navigator.internal.NavigatorDisposableEffect
 import cafe.adriel.voyager.navigator.internal.rememberNavigator
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 public typealias NavigatorContent = @Composable (navigator: Navigator) -> Unit
 
@@ -66,14 +71,25 @@ public fun Navigator(
         LocalNavigatorStateHolder providesDefault rememberSaveableStateHolder()
     ) {
         val navigator = rememberNavigator(screens, LocalNavigator.current)
-        val lifecycleOwner = rememberScreenLifecycleOwner(navigator.lastItem)
+        val currentScreen = navigator.lastItem
+        val lifecycleOwner = rememberScreenLifecycleOwner(currentScreen)
         val hooks = lifecycleOwner.getHooks()
 
         CompositionLocalProvider(
             LocalNavigator provides navigator,
             *hooks.providers.toTypedArray()
         ) {
-            if (autoDispose) NavigatorDisposableEffect(navigator, hooks.onDispose)
+            // Each screen will have a transition callback by default
+            val transitionCallback = remember(currentScreen.key) {
+                TransitionCallbackImpl(onDispose = hooks.onDispose).apply {
+                    navigator.registerTransitionCallback(currentScreen, this)
+                }
+            }
+
+            // We don't need concurrent disposable when we have transitions
+            if (autoDispose && navigator.hasTransitionCallback.not()) {
+                NavigatorDisposableEffect(navigator, transitionCallback)
+            }
 
             NavigatorBackHandler(navigator, onBackPressed)
 
@@ -87,6 +103,16 @@ public class Navigator internal constructor(
     public val stateHolder: SaveableStateHolder,
     public val parent: Navigator? = null
 ) : Stack<Screen> by screens.toMutableStateStack(minSize = 1) {
+    private val transitionCallbacks = ConcurrentHashMap<Screen, TransitionCallback>()
+    private val registeredTransitions = AtomicBoolean(false)
+
+    internal fun registerTransitionCallback(screen: Screen, transitionCallback: TransitionCallback) {
+        transitionCallbacks[screen] = transitionCallback
+    }
+
+    internal fun unregisterTransitionCallback(screen: Screen) {
+        transitionCallbacks.remove(screen)
+    }
 
     public val level: Int =
         parent?.level?.inc() ?: 0
@@ -103,6 +129,19 @@ public class Navigator internal constructor(
         lastItem
     }
 
+    // TODO: it would be nice don't have variables and functions public related to transitions
+    public val hasTransitionCallback: Boolean
+        get() = registeredTransitions.get()
+
+    public fun notifyTransitionEnd(previous: Screen) {
+        val callback = transitionCallbacks.remove(previous)
+        callback?.onTransitionEnd(navigator = this, previous = previous)
+    }
+
+    public fun registerToDisposeAfterTransitionEnd(screenToDispose: Screen) {
+        registeredTransitions.compareAndSet(false, transitionCallbacks.containsKey(screenToDispose))
+    }
+
     public fun popUntilRoot() {
         popUntilRoot(this)
     }
@@ -115,5 +154,32 @@ public class Navigator internal constructor(
         } else {
             popUntilRoot(navigator.parent)
         }
+    }
+}
+
+/**
+ * A fallback when a screen was replaced by other
+ */
+internal interface TransitionCallback {
+    /**
+     * Called when previous screen is totally invisible
+     *
+     * @param navigator The navigator in the current transition
+     * @param previous The screen that was popped/replaced
+     */
+    fun onTransitionEnd(navigator: Navigator, previous: Screen)
+}
+
+internal data class TransitionCallbackImpl(
+    private val onDispose: () -> Unit
+) : TransitionCallback {
+    override fun onTransitionEnd(navigator: Navigator, previous: Screen) {
+        // TODO: Maybe dispose operations should be called inside remove operations instead here
+        onDispose()
+        ScreenModelStore.remove(previous)
+        ScreenLifecycleStore.remove(previous)
+        navigator.stateHolder.removeState(previous.key)
+        navigator.clearEvent()
+        navigator.unregisterTransitionCallback(previous)
     }
 }

--- a/voyager-navigator/src/jvmMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
+++ b/voyager-navigator/src/jvmMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
@@ -19,7 +19,9 @@ internal fun NavigatorDisposableEffect(
 
     DisposableEffect(currentScreen.key) {
         onDispose {
-            if (navigator.lastEvent in disposableEvents) {
+            val disposePreviousScreen = navigator.lastEvent in disposableEvents
+            val disposeInitialScreen = navigator.lastEvent == StackEvent.Idle && navigator.canPop.not()
+            if (disposePreviousScreen || disposeInitialScreen) {
                 onDispose()
                 ScreenModelStore.remove(currentScreen)
                 ScreenLifecycleStore.remove(currentScreen)

--- a/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/FadeTransition.kt
+++ b/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/FadeTransition.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.with
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.navigator.Navigator
 
@@ -18,12 +17,14 @@ public fun FadeTransition(
     navigator: Navigator,
     modifier: Modifier = Modifier,
     animationSpec: FiniteAnimationSpec<Float> = spring(stiffness = Spring.StiffnessMediumLow),
+    onTransitionEnd: () -> Unit = {},
     content: ScreenTransitionContent = { it.Content() }
 ) {
     ScreenTransition(
         navigator = navigator,
         modifier = modifier,
         content = content,
+        onTransitionEnd = onTransitionEnd,
         transition = { fadeIn(animationSpec = animationSpec) with fadeOut(animationSpec = animationSpec) }
     )
 }

--- a/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/ScaleTransition.kt
+++ b/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/ScaleTransition.kt
@@ -21,12 +21,14 @@ public fun ScaleTransition(
     navigator: Navigator,
     modifier: Modifier = Modifier,
     animationSpec: FiniteAnimationSpec<Float> = spring(stiffness = Spring.StiffnessMediumLow),
+    onTransitionEnd: () -> Unit = {},
     content: ScreenTransitionContent = { it.Content() }
 ) {
     ScreenTransition(
         navigator = navigator,
         modifier = modifier,
         content = content,
+        onTransitionEnd = onTransitionEnd,
         transition = {
             val (initialScale, targetScale) = when (navigator.lastEvent) {
                 StackEvent.Pop -> ExitScales

--- a/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/SlideTransition.kt
+++ b/voyager-transitions/src/main/java/cafe/adriel/voyager/transitions/SlideTransition.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.with
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import cafe.adriel.voyager.core.stack.StackEvent
@@ -27,12 +26,14 @@ public fun SlideTransition(
         stiffness = Spring.StiffnessMediumLow,
         visibilityThreshold = IntOffset.VisibilityThreshold
     ),
+    onTransitionEnd: () -> Unit = {},
     content: ScreenTransitionContent = { it.Content() }
 ) {
     ScreenTransition(
         navigator = navigator,
         modifier = modifier,
         content = content,
+        onTransitionEnd = onTransitionEnd,
         transition = {
             val (initialOffset, targetOffset) = when (navigator.lastEvent) {
                 StackEvent.Pop -> ({ size: Int -> -size }) to ({ size: Int -> size })


### PR DESCRIPTION
Here is try to fix when we are in the first screen and hit back press closing the activity. But the first screen on navigator was not calling disposing function after back press.

So now it will call ScreenModel onDispose or ViewModel onCleared when hit onBackPress in the first screen on Navigator.

This PR is a try to fix #20 and #23 too