### PR TITLE
fix: SavedStateProvider with the given key is already registered

### DIFF
--- a/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/VoyagerHiltViewModelFactories.kt
+++ b/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/VoyagerHiltViewModelFactories.kt
@@ -1,0 +1,50 @@
+package cafe.adriel.voyager.hilt
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.SavedStateViewModelFactory
+import androidx.lifecycle.ViewModelProvider
+import androidx.savedstate.SavedStateRegistryOwner
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.internal.builders.ViewModelComponentBuilder
+import dagger.hilt.android.internal.lifecycle.HiltViewModelFactory
+import dagger.hilt.android.internal.lifecycle.HiltViewModelMap
+import javax.inject.Inject
+
+public object VoyagerHiltViewModelFactories {
+
+    public fun getVoyagerFactory(
+        activity: ComponentActivity,
+        owner: SavedStateRegistryOwner,
+        delegateFactory: ViewModelProvider.Factory?
+    ): ViewModelProvider.Factory {
+        return EntryPoints.get(activity, ViewModelFactoryEntryPoint::class.java)
+            .internalViewModelFactory()
+            .fromActivity(activity, owner, delegateFactory)
+    }
+
+    internal class InternalViewModelFactory @Inject internal constructor(
+        private val application: Application,
+        @HiltViewModelMap.KeySet private val keySet: Set<String>,
+        private val viewModelComponentBuilder: ViewModelComponentBuilder
+    ) {
+        fun fromActivity(
+            activity: ComponentActivity,
+            owner: SavedStateRegistryOwner,
+            delegateFactory: ViewModelProvider.Factory?
+        ): ViewModelProvider.Factory {
+            val defaultArgs = activity.intent?.extras
+            val delegate = delegateFactory ?: SavedStateViewModelFactory(application, owner, defaultArgs)
+            return HiltViewModelFactory(owner, defaultArgs, keySet, delegate, viewModelComponentBuilder)
+        }
+    }
+
+    @EntryPoint
+    @InstallIn(ActivityComponent::class)
+    internal interface ViewModelFactoryEntryPoint {
+        fun internalViewModelFactory(): InternalViewModelFactory
+    }
+}

--- a/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/internal/ContextExt.kt
+++ b/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/internal/ContextExt.kt
@@ -2,13 +2,8 @@ package cafe.adriel.voyager.hilt.internal
 
 import android.content.Context
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.ViewModelProvider
 
 @PublishedApi
 internal val Context.componentActivity: ComponentActivity
     get() = this as? ComponentActivity
         ?: error("Invalid local context. It must be a ComponentActivity")
-
-@PublishedApi
-internal val Context.defaultViewModelProviderFactory: ViewModelProvider.Factory
-    get() = componentActivity.defaultViewModelProviderFactory


### PR DESCRIPTION
Default ViewModelFactory provided by Hilt was using your own StateProviderOwner instead of `AndroidScreenLifecycleOwner`. So keys were kept in the activity owner and the instance in the `AndroidScreenLifecycleOwner`.
Behavior reported here: #20 