### PR TITLE
fix: Jetbrains Compose transitive dependencies on Android projects

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/voyager-bottom-sheet-navigator/build.gradle.kts
+++ b/voyager-bottom-sheet-navigator/build.gradle.kts
@@ -52,6 +52,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-bottom-sheet-navigator/build.gradle.kts
+++ b/voyager-bottom-sheet-navigator/build.gradle.kts
@@ -26,8 +26,8 @@ kotlin {
             dependencies {
                 api(projects.voyagerCore)
                 api(projects.voyagerNavigator)
-                implementation(compose.runtime)
-                implementation(compose.material)
+                compileOnly(compose.runtime)
+                compileOnly(compose.material)
             }
         }
         val desktopMain by getting {

--- a/voyager-core/build.gradle.kts
+++ b/voyager-core/build.gradle.kts
@@ -47,6 +47,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-core/build.gradle.kts
+++ b/voyager-core/build.gradle.kts
@@ -24,8 +24,8 @@ kotlin {
         val jvmMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                compileOnly(compose.runtime)
+                compileOnly(compose.ui)
             }
         }
         val desktopMain by getting {

--- a/voyager-kodein/build.gradle.kts
+++ b/voyager-kodein/build.gradle.kts
@@ -48,6 +48,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-kodein/build.gradle.kts
+++ b/voyager-kodein/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
             dependsOn(commonMain)
             dependencies {
                 api(projects.voyagerCore)
-                implementation(compose.runtime)
+                compileOnly(compose.runtime)
                 implementation(libs.kodein)
             }
         }

--- a/voyager-navigator/build.gradle.kts
+++ b/voyager-navigator/build.gradle.kts
@@ -25,8 +25,8 @@ kotlin {
             dependsOn(commonMain)
             dependencies {
                 api(projects.voyagerCore)
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                compileOnly(compose.runtime)
+                compileOnly(compose.ui)
             }
         }
         val desktopMain by getting {

--- a/voyager-navigator/build.gradle.kts
+++ b/voyager-navigator/build.gradle.kts
@@ -51,6 +51,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-tab-navigator/build.gradle.kts
+++ b/voyager-tab-navigator/build.gradle.kts
@@ -49,6 +49,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-tab-navigator/build.gradle.kts
+++ b/voyager-tab-navigator/build.gradle.kts
@@ -26,8 +26,8 @@ kotlin {
             dependencies {
                 api(projects.voyagerCore)
                 api(projects.voyagerNavigator)
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                compileOnly(compose.runtime)
+                compileOnly(compose.ui)
             }
         }
         val desktopMain by getting {

--- a/voyager-transitions/build.gradle.kts
+++ b/voyager-transitions/build.gradle.kts
@@ -48,6 +48,10 @@ kotlin {
         }
         val androidTest by getting {
             dependsOn(jvmTest)
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.ui)
+            }
         }
     }
 }

--- a/voyager-transitions/build.gradle.kts
+++ b/voyager-transitions/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
             dependencies {
                 api(projects.voyagerCore)
                 api(projects.voyagerNavigator)
-                implementation(compose.animation)
+                compileOnly(compose.animation)
             }
         }
         val desktopMain by getting {


### PR DESCRIPTION
This PR fixes the issue from the #34 by removing Jetbrains Compose transitive dependencies on all targets.