### PR TITLE
fix: initial screen and its model not disposing

### DIFF
--- a/samples/multiplatform/build.gradle.kts
+++ b/samples/multiplatform/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.compose.compose
-import org.jetbrains.compose.desktop.application.dsl.TargetFormat.*
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat.Deb
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat.Dmg
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat.Msi
 
 plugins {
     kotlin("multiplatform")

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleHooks.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleHooks.kt
@@ -3,8 +3,7 @@ package cafe.adriel.voyager.core.lifecycle
 import androidx.compose.runtime.ProvidedValue
 
 public data class ScreenLifecycleHooks(
-    val providers: List<ProvidedValue<*>> = emptyList(),
-    val onDispose: () -> Unit = {}
+    val providers: List<ProvidedValue<*>> = emptyList()
 ) {
 
     internal companion object {

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleOwner.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleOwner.kt
@@ -1,11 +1,14 @@
 package cafe.adriel.voyager.core.lifecycle
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.core.screen.Screen
 
 public interface ScreenLifecycleOwner {
 
     @Composable
     public fun getHooks(): ScreenLifecycleHooks = ScreenLifecycleHooks.Empty
+
+    public fun onDispose(screen: Screen) {}
 }
 
 internal object DefaultScreenLifecycleOwner : ScreenLifecycleOwner

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleStore.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleStore.kt
@@ -15,6 +15,6 @@ public object ScreenLifecycleStore {
         owners.getOrPut(screen.key) { factory(screen.key) }
 
     public fun remove(screen: Screen) {
-        owners -= screen.key
+        owners.remove(screen.key)?.onDispose(screen)
     }
 }

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
@@ -12,15 +12,13 @@ private val disposableEvents: Set<StackEvent> =
 
 @Composable
 internal fun NavigatorDisposableEffect(
-    navigator: Navigator,
-    onDispose: () -> Unit
+    navigator: Navigator
 ) {
     val currentScreen = navigator.lastItem
 
     DisposableEffect(currentScreen.key) {
         onDispose {
             if (navigator.lastEvent in disposableEvents) {
-                onDispose()
                 ScreenModelStore.remove(currentScreen)
                 ScreenLifecycleStore.remove(currentScreen)
                 navigator.stateHolder.removeState(currentScreen.key)


### PR DESCRIPTION
This fix is because Navigator dispose checks the last disposed or replaced screen. But first navigator screen will be never popped or replaced because Navigator needs at least one screen to work. Pressing back button or closing applications never dispose first screen.
So here we are putting a effect to dispose based on Navigator been replaced or application been finished. And if a Navigator is totally replaced by another (yes, we can't avoid users does that) it'll will dispose all pushed screens.