### PR TITLE
Downgrade jvmTarget to Java 1.8 for compatibility

### DIFF
--- a/buildSrc/src/main/kotlin/Setup.kt
+++ b/buildSrc/src/main/kotlin/Setup.kt
@@ -43,8 +43,8 @@ fun Project.setupModuleForAndroidxCompose(
         }
 
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
 
         testOptions {
@@ -114,7 +114,7 @@ fun Project.setupModuleForComposeMultiplatform(
 private fun KotlinJvmOptions.configureKotlinJvmOptions(
     enableExplicitMode: Boolean
 ) {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
 
     if(enableExplicitMode) freeCompilerArgs += "-Xexplicit-api=strict"
 }


### PR DESCRIPTION
To increase the library compatibility with other projects, we should target java 8 for bytecode compatibility compilation.