### PR TITLE
Fix Lifecycle issues

### DIFF
--- a/voyager-androidx/src/main/java/cafe/adriel/voyager/androidx/AndroidScreenLifecycleOwner.kt
+++ b/voyager-androidx/src/main/java/cafe/adriel/voyager/androidx/AndroidScreenLifecycleOwner.kt
@@ -40,14 +40,30 @@ public class AndroidScreenLifecycleOwner private constructor() :
         if (controller.savedStateRegistry.isRestored.not()) {
             controller.performRestore(null)
         }
-        initStates.forEach { registry.currentState = it }
+        initEvents.forEach {
+            registry.handleLifecycleEvent(it)
+        }
+    }
+
+    override fun onStart() {
+        startEvents.forEach {
+            registry.handleLifecycleEvent(it)
+        }
+    }
+
+    override fun onStop() {
+        stopEvents.forEach {
+            registry.handleLifecycleEvent(it)
+        }
     }
 
     override fun onDispose(screen: Screen) {
         val context = atomicContext.getAndSet(null) ?: return
         if (context is Activity && context.isChangingConfigurations) return
         viewModelStore.clear()
-        disposeStates.forEach { registry.currentState = it }
+        disposeEvents.forEach {
+            registry.handleLifecycleEvent(it)
+        }
     }
 
     @Composable
@@ -73,15 +89,22 @@ public class AndroidScreenLifecycleOwner private constructor() :
 
     public companion object {
 
-        private val initStates = arrayOf(
-            Lifecycle.State.INITIALIZED,
-            Lifecycle.State.CREATED,
-            Lifecycle.State.STARTED,
-            Lifecycle.State.RESUMED
+        private val initEvents = arrayOf(
+            Lifecycle.Event.ON_CREATE,
         )
 
-        private val disposeStates = arrayOf(
-            Lifecycle.State.DESTROYED
+        private val startEvents = arrayOf(
+            Lifecycle.Event.ON_START,
+            Lifecycle.Event.ON_RESUME
+        )
+
+        private val stopEvents = arrayOf(
+            Lifecycle.Event.ON_PAUSE,
+            Lifecycle.Event.ON_STOP
+        )
+
+        private val disposeEvents = arrayOf(
+            Lifecycle.Event.ON_DESTROY
         )
 
         public fun get(screen: Screen): ScreenLifecycleOwner =

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleOwner.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/lifecycle/ScreenLifecycleOwner.kt
@@ -9,6 +9,10 @@ public interface ScreenLifecycleOwner {
     public fun getHooks(): ScreenLifecycleHooks = ScreenLifecycleHooks.Empty
 
     public fun onDispose(screen: Screen) {}
+
+    public fun onStart() {}
+
+    public fun onStop() {}
 }
 
 internal object DefaultScreenLifecycleOwner : ScreenLifecycleOwner

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorDisposable.kt
@@ -2,6 +2,7 @@ package cafe.adriel.voyager.navigator.internal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import cafe.adriel.voyager.core.lifecycle.ScreenLifecycleOwner
 import cafe.adriel.voyager.core.stack.StackEvent
 import cafe.adriel.voyager.navigator.Navigator
 
@@ -35,5 +36,15 @@ internal fun StepDisposableEffect(
                 navigator.clearEvent()
             }
         }
+    }
+}
+
+@Composable
+internal fun LifecycleDisposableEffect(
+    lifecycleOwner: ScreenLifecycleOwner
+) {
+    DisposableEffect(lifecycleOwner) {
+        lifecycleOwner.onStart()
+        onDispose(lifecycleOwner::onStop)
     }
 }


### PR DESCRIPTION
Closes #42
Closes #79

Handle Lifecycle.Event instead of managing the states themselves, include a onStart and onStop function to say when the screen is displayed.

Note that this fix is included in my fork of Voyager https://github.com/Syer10/voyager