### PR TITLE
Add replaceAll overload to allow replacing a stack with another

### DIFF
--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/SnapshotStateStack.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/SnapshotStateStack.kt
@@ -95,12 +95,6 @@ public class SnapshotStateStack<Item>(
         stateStack.size > minSize
     }
 
-    override fun replaceAll(items: List<Item>) {
-        stateStack.clear()
-        stateStack += items
-        lastEvent = StackEvent.Replace
-    }
-
     public override infix fun push(item: Item) {
         stateStack += item
         lastEvent = StackEvent.Push
@@ -120,6 +114,12 @@ public class SnapshotStateStack<Item>(
     public override infix fun replaceAll(item: Item) {
         stateStack.clear()
         stateStack += item
+        lastEvent = StackEvent.Replace
+    }
+
+    public override infix fun replaceAll(items: List<Item>) {
+        stateStack.clear()
+        stateStack += items
         lastEvent = StackEvent.Replace
     }
 

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/SnapshotStateStack.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/SnapshotStateStack.kt
@@ -95,6 +95,12 @@ public class SnapshotStateStack<Item>(
         stateStack.size > minSize
     }
 
+    override fun replaceAll(items: List<Item>) {
+        stateStack.clear()
+        stateStack += items
+        lastEvent = StackEvent.Replace
+    }
+
     public override infix fun push(item: Item) {
         stateStack += item
         lastEvent = StackEvent.Push

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/Stack.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/stack/Stack.kt
@@ -38,6 +38,8 @@ public interface Stack<Item> {
 
     public infix fun replaceAll(item: Item)
 
+    public infix fun replaceAll(items: List<Item>)
+
     public fun pop(): Boolean
 
     public fun popAll()


### PR DESCRIPTION
creates `replaceAll(items: List<Item>)` allowing a step to replace the navigation stack with another stack