### PR TITLE
Use UUID for unique key

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ composeMaterial = "1.3.1"
 composeRuntime = "1.3.3"
 composeUI = "1.3.3"
 
+uuid = "0.7.0"
+
 junit = "5.8.2"
 
 [libraries]
@@ -53,6 +55,8 @@ compose-materialIcons = { module = "androidx.compose.material:material-icons-cor
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "composeActivity" }
 
 composeMultiplatform-runtimeSaveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "plugin-multiplatform-compose" }
+
+uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
 
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }

--- a/voyager-core/build.gradle.kts
+++ b/voyager-core/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 api(compose.runtime)
                 api(libs.composeMultiplatform.runtimeSaveable)
                 implementation(libs.coroutines)
+                implementation(libs.uuid)
             }
         }
         val jvmTest by getting {

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/screen/ScreenKey.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/screen/ScreenKey.kt
@@ -1,10 +1,8 @@
 package cafe.adriel.voyager.core.screen
 
-import cafe.adriel.voyager.core.concurrent.AtomicInt32
+import com.benasher44.uuid.uuid4
 
 public typealias ScreenKey = String
 
-private val nextScreenKey = AtomicInt32(0)
-
 public val Screen.uniqueScreenKey: ScreenKey
-    get() = "Screen#${nextScreenKey.getAndIncrement()}"
+    get() = "Screen#${uuid4()}"


### PR DESCRIPTION
This fixes an issue with Android where if the app is killed but then restored, the AtomicInt restarts at 0. This will guarantee uniqueness between app restarts.