### PR TITLE
Add key to navigator to fix restore on nested navigators

### DIFF
--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/bottomSheetNavigation/BottomSheetNavigationActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/bottomSheetNavigation/BottomSheetNavigationActivity.kt
@@ -14,8 +14,8 @@ class BottomSheetNavigationActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            BottomSheetNavigator {
-                Navigator(BackScreen())
+            BottomSheetNavigator(key = "BottomSheet") {
+                Navigator(BackScreen(), key = "MainNavigator")
             }
         }
     }

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/nestedNavigation/NestedNavigationActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/nestedNavigation/NestedNavigationActivity.kt
@@ -35,11 +35,11 @@ class NestedNavigationActivity : ComponentActivity() {
 
     @Composable
     private fun Content() {
-        NestedNavigation(backgroundColor = Color.Gray) {
+        NestedNavigation(backgroundColor = Color.Gray, "1") {
             CurrentScreen()
-            NestedNavigation(backgroundColor = Color.LightGray) {
+            NestedNavigation(backgroundColor = Color.LightGray, "2") {
                 CurrentScreen()
-                NestedNavigation(backgroundColor = Color.White) { navigator ->
+                NestedNavigation(backgroundColor = Color.White, "3") { navigator ->
                     CurrentScreen()
                     Button(
                         onClick = { navigator.popUntilRoot() },
@@ -55,7 +55,8 @@ class NestedNavigationActivity : ComponentActivity() {
     @Composable
     private fun NestedNavigation(
         backgroundColor: Color,
-        content: NavigatorContent = { CurrentScreen() }
+        key: String,
+        content: NavigatorContent = { CurrentScreen() },
     ) {
         Navigator(
             screen = BasicNavigationScreen(index = 0, wrapContent = true)

--- a/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
+++ b/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
@@ -38,6 +38,7 @@ public val LocalBottomSheetNavigator: ProvidableCompositionLocal<BottomSheetNavi
 @Composable
 public fun BottomSheetNavigator(
     modifier: Modifier = Modifier,
+    key: String? = null,
     hideOnBackPress: Boolean = true,
     scrimColor: Color = ModalBottomSheetDefaults.scrimColor,
     sheetShape: Shape = MaterialTheme.shapes.large,
@@ -62,7 +63,7 @@ public fun BottomSheetNavigator(
         }
     )
 
-    Navigator(HiddenBottomSheetScreen, onBackPressed = null) { navigator ->
+    Navigator(HiddenBottomSheetScreen, key = key, onBackPressed = null) { navigator ->
         val bottomSheetNavigator = remember(navigator, sheetState, coroutineScope) {
             BottomSheetNavigator(navigator, sheetState, coroutineScope)
         }

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
@@ -46,12 +46,14 @@ public fun CurrentScreen() {
 @Composable
 public fun Navigator(
     screen: Screen,
+    key: String? = null,
     disposeBehavior: NavigatorDisposeBehavior = NavigatorDisposeBehavior(),
     onBackPressed: OnBackPressed = { true },
     content: NavigatorContent = { CurrentScreen() }
 ) {
     Navigator(
         screens = listOf(screen),
+        key = key,
         disposeBehavior = disposeBehavior,
         onBackPressed = onBackPressed,
         content = content
@@ -61,6 +63,7 @@ public fun Navigator(
 @Composable
 public fun Navigator(
     screens: List<Screen>,
+    key: String? = null,
     disposeBehavior: NavigatorDisposeBehavior = NavigatorDisposeBehavior(),
     onBackPressed: OnBackPressed = { true },
     content: NavigatorContent = { CurrentScreen() }
@@ -70,7 +73,7 @@ public fun Navigator(
     CompositionLocalProvider(
         LocalNavigatorStateHolder providesDefault rememberSaveableStateHolder()
     ) {
-        val navigator = rememberNavigator(screens, disposeBehavior, LocalNavigator.current)
+        val navigator = rememberNavigator(screens, key, disposeBehavior, LocalNavigator.current)
 
         if (navigator.parent?.disposeBehavior?.disposeNestedNavigators != false) {
             NavigatorDisposableEffect(navigator)

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorSaver.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorSaver.kt
@@ -17,12 +17,13 @@ internal val LocalNavigatorStateHolder: ProvidableCompositionLocal<SaveableState
 @Composable
 internal fun rememberNavigator(
     screens: List<Screen>,
+    key: String? = null,
     disposeBehavior: NavigatorDisposeBehavior,
     parent: Navigator?
 ): Navigator {
     val stateHolder = LocalNavigatorStateHolder.current
 
-    return rememberSaveable(saver = navigatorSaver(stateHolder, disposeBehavior, parent)) {
+    return rememberSaveable(saver = navigatorSaver(stateHolder, disposeBehavior, parent), key = key) {
         Navigator(screens, stateHolder, disposeBehavior, parent)
     }
 }

--- a/voyager-tab-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/tab/TabNavigator.kt
+++ b/voyager-tab-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/tab/TabNavigator.kt
@@ -16,11 +16,13 @@ public val LocalTabNavigator: ProvidableCompositionLocal<TabNavigator> =
 @Composable
 public fun TabNavigator(
     tab: Tab,
+    key: String? = null,
     disposeNestedNavigators: Boolean = false,
     content: TabNavigatorContent = { CurrentTab() }
 ) {
     Navigator(
         screen = tab,
+        key = key,
         disposeBehavior = NavigatorDisposeBehavior(
             disposeNestedNavigators = disposeNestedNavigators,
             disposeSteps = false


### PR DESCRIPTION
To test this issue do this
1. Checkout my nested restore sample branch https://github.com/Syer10/voyager/tree/nested_restore_sample
2. Click a few screens to put stuff on the backstack
3. Put the app in the background for a few seconds
4. Run `adb shell am kill cafe.adriel.voyager.sample.test` in the terminal
5. Select the app in the recent apps window
6. It should restore properly, without this PR it fails to restore and sometimes crashes,