### PR TITLE
Added support to expand skip half expanded mode

### DIFF
--- a/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
+++ b/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
@@ -44,6 +44,7 @@ public fun BottomSheetNavigator(
     sheetElevation: Dp = ModalBottomSheetDefaults.Elevation,
     sheetBackgroundColor: Color = MaterialTheme.colors.surface,
     sheetContentColor: Color = contentColorFor(sheetBackgroundColor),
+    skipHalfExpanded: Boolean = true,
     sheetContent: BottomSheetNavigatorContent = { CurrentScreen() },
     content: BottomSheetNavigatorContent
 ) {
@@ -51,6 +52,7 @@ public fun BottomSheetNavigator(
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = skipHalfExpanded,
         confirmStateChange = { state ->
             when (state) {
                 ModalBottomSheetValue.Hidden -> {


### PR DESCRIPTION
Closes #122 

Adds `skipHalfExpanded` in the parameters to enable bottom sheet to show in full mode.