### PR TITLE
Updated kodein and changed the module multoplatform flag

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-multiplatform-compose = "1.4.0"
 
 coroutines = "1.6.4"
 kotlin = "1.8.20"
-kodein = "7.18.0"
+kodein = "7.20.1"
 koin = "3.2.2"
 hilt = "2.44"
 leakCanary = "2.8.1"

--- a/voyager-kodein/build.gradle.kts
+++ b/voyager-kodein/build.gradle.kts
@@ -5,8 +5,7 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-// Support fully when https://github.com/kosi-libs/Kodein/pull/431 get merged.
-setupModuleForComposeMultiplatform()
+setupModuleForComposeMultiplatform(fullyMultiplatform = true)
 
 android {
     namespace = "cafe.adriel.voyager.kodein"


### PR DESCRIPTION
Now that the [multiplatform branch for kmm on kodein](https://github.com/kosi-libs/Kodein/pull/431) is merged and release on the `version 7.19.0`, I decided to bump the version to the `7.20.1` and make the kodein wrapper compatible.