### PR TITLE
Use `Dispatchers.Main.immediate` instead of `Dispatchers.Main` for ScreenModel's `coroutineScope`

### DIFF
--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModel.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModel.kt
@@ -6,18 +6,18 @@ import androidx.compose.runtime.remember
 import cafe.adriel.voyager.core.screen.Screen
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.plus
 
 public val ScreenModel.coroutineScope: CoroutineScope
     get() = ScreenModelStore.getOrPutDependency(
         screenModel = this,
         name = "ScreenModelCoroutineScope",
-        factory = { key -> MainScope() + CoroutineName(key) },
+        factory = { key -> CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate + CoroutineName(key)) },
         onDispose = { scope -> scope.cancel() }
     )
 


### PR DESCRIPTION
There is no need to do unnecessary dispatching using `Dispatchers.Main` since ScreenModel's operations are intended to run immediately on the main thread, this matches what [AndroidX ViewModel](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:lifecycle/lifecycle-viewmodel-ktx/src/main/java/androidx/lifecycle/ViewModel.kt;l=35?q=viewModelScope&sq=&ss=androidx%2Fplatform%2Fframeworks%2Fsupport) is doing for `viewModelScope` property. 
Also, `Dispatcher.Main.immediate` is available on Android, Apple platforms, Web (JS), JavaFX(Desktop). So, it should be safe to use it in the `commonMain`