### PR TITLE
Fix bottom sheet dismiss on click outside issue

### DIFF
--- a/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
+++ b/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
@@ -119,6 +119,9 @@ public class BottomSheetNavigator internal constructor(
             if (isVisible) {
                 sheetState.hide()
                 replaceAll(HiddenBottomSheetScreen)
+            } else if (sheetState.targetValue == ModalBottomSheetValue.Hidden) {
+                // Swipe down - sheetState is already hidden here so `isVisible` is false
+                replaceAll(HiddenBottomSheetScreen)
             }
         }
     }


### PR DESCRIPTION
Fixes #203
Fixes #221 

`isVisible` is `false` when we click outside the bottom sheet so it is not being removed from the stack.

This happens because we are NOT vetoing bottom sheet state change so when it arrives in Voyager's `hide()` is already hiding. This is the solution for now, before the release I will look into this veto issue.

**To reproduce**
1. Run `samples:android` and click "Bottom Sheet Navigation" button;
2. Open logs, `BasicNavigationScreen` has a `LifecycleEffect` that logs onStarted/onDisposed.
3. Click "Show BottomSheet"
  3.1. **Swipe down**: hidden, disposed and replaced by HiddenBottomSheet
  3.2. **Add a button** inside `BasicNavigationScreen` **that calls** `bottomSheetNavigator.hide()`, click on it: hidden, disposed and replaced by HiddenBottomSheet
  3.2. **Click outside** the bottom sheet: hidden, not disposed and still on stack (this should work now).

Don't add `if (isVisible || sheetState.targetValue == ModalBottomSheetValue.Hidden)` because `hide()` tries again (again because hide was already requested internally by outside click) to close the bottom sheet but outer CoroutineScope is already in a "near to cancel" state, only waiting animation to end so `hide()` throws a CancellationException and `replaceAll` do not get called at all