### PR TITLE
Navigator scoped ScreenModel

### DIFF
--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModelStore.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModelStore.kt
@@ -30,9 +30,7 @@ public object ScreenModelStore : ScreenDisposable {
     internal inline fun <reified T : ScreenModel> getKey(screen: Screen, tag: String?): ScreenModelKey =
         getKey<T>(screen.key, tag)
 
-    /**
-     * Public: used in Navigator Scoped ScreenModels
-     */
+    // Public: used in Navigator Scoped ScreenModels
     @InternalVoyagerApi
     public inline fun <reified T : ScreenModel> getKey(holderKey: String, tag: String?): ScreenModelKey =
         "${holderKey}:${T::class.multiplatformName}:${tag ?: "default"}"
@@ -58,9 +56,7 @@ public object ScreenModelStore : ScreenDisposable {
         factory: @DisallowComposableCalls () -> T
     ): T = getOrPut(screen.key, tag, factory)
 
-    /**
-     * Public: used in Navigator Scoped ScreenModels
-     */
+    // Public: used in Navigator Scoped ScreenModels
     @InternalVoyagerApi
     public inline fun <reified T : ScreenModel> getOrPut(
         holderKey: String,
@@ -89,9 +85,7 @@ public object ScreenModelStore : ScreenDisposable {
         disposeHolder(screen.key)
     }
 
-    /**
-     * Public: used in Navigator Scoped ScreenModels
-     */
+    // Public: used in Navigator Scoped ScreenModels
     @InternalVoyagerApi
     public fun onDisposeNavigator(navigatorKey: String) {
         disposeHolder(navigatorKey)

--- a/voyager-hilt/build.gradle.kts
+++ b/voyager-hilt/build.gradle.kts
@@ -20,6 +20,7 @@ kapt {
 
 dependencies {
     api(projects.voyagerAndroidx)
+    api(projects.voyagerNavigator)
 
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui)

--- a/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/ScreenModel.kt
+++ b/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/ScreenModel.kt
@@ -2,10 +2,13 @@ package cafe.adriel.voyager.hilt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.hilt.internal.componentActivity
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.screenModel.rememberNavigatorScreenModel
 import dagger.hilt.android.EntryPointAccessors
 
 /**
@@ -53,6 +56,59 @@ public inline fun <reified T : ScreenModel, reified F : ScreenModelFactory> Scre
                 "${F::class.java} not found in hilt graph.\nPlease, check if you have a Multibinding " +
                     "declaration to your ScreenModelFactory using @IntoMap and " +
                     "@ScreenModelFactoryKey(${F::class.qualifiedName}::class)"
+            )
+        factory.invoke(screenFactory as F)
+    }
+}
+
+/**
+ * Provide a [ScreenModel] getting from Hilt graph, lifecycle bounded to the Navigator.
+ *
+ * @return A new instance of [ScreenModel] or the same instance remembered by the composition
+ */
+@ExperimentalVoyagerApi
+@Composable
+public inline fun <reified T : ScreenModel> Navigator.getNavigatorScreenModel(
+    tag: String? = null
+): T {
+    val context = LocalContext.current
+    return rememberNavigatorScreenModel(tag) {
+        val screenModels = EntryPointAccessors
+            .fromActivity(context.componentActivity, ScreenModelEntryPoint::class.java)
+            .screenModels()
+        val model = screenModels[T::class.java]?.get()
+            ?: error(
+                "${T::class.java} not found in hilt graph.\nPlease, check if you have a Multibinding " +
+                        "declaration to your ScreenModel using @IntoMap and " +
+                        "@ScreenModelKey(${T::class.qualifiedName}::class)"
+            )
+        model as T
+    }
+}
+
+/**
+ * Provide a [ScreenModel] using a custom [ScreenModelFactory], lifecycle bounded to the Navigator.
+ * The [ScreenModelFactory] is provided by Hilt graph.
+ *
+ * @param factory A function that receives a [ScreenModelFactory] and returns a [ScreenModel] created by the custom factory
+ * @return A new instance of [ScreenModel] or the same instance remembered by the composition
+ */
+@ExperimentalVoyagerApi
+@Composable
+public inline fun <reified T : ScreenModel, reified F : ScreenModelFactory> Navigator.getNavigatorScreenModel(
+    tag: String? = null,
+    noinline factory: (F) -> T
+): T {
+    val context = LocalContext.current
+    return rememberNavigatorScreenModel(tag) {
+        val screenFactories = EntryPointAccessors
+            .fromActivity(context.componentActivity, ScreenModelEntryPoint::class.java)
+            .screenModelFactories()
+        val screenFactory = screenFactories[F::class.java]?.get()
+            ?: error(
+                "${F::class.java} not found in hilt graph.\nPlease, check if you have a Multibinding " +
+                        "declaration to your ScreenModelFactory using @IntoMap and " +
+                        "@ScreenModelFactoryKey(${F::class.qualifiedName}::class)"
             )
         factory.invoke(screenFactory as F)
     }

--- a/voyager-kodein/build.gradle.kts
+++ b/voyager-kodein/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(projects.voyagerCore)
-                implementation(projects.voyagerNavigator)
+                api(projects.voyagerNavigator)
                 compileOnly(compose.runtime)
                 compileOnly(compose.runtimeSaveable)
                 implementation(libs.kodein)

--- a/voyager-kodein/src/commonMain/kotlin/cafe/adriel/voyager/kodein/ScreenModel.kt
+++ b/voyager-kodein/src/commonMain/kotlin/cafe/adriel/voyager/kodein/ScreenModel.kt
@@ -1,9 +1,12 @@
 package cafe.adriel.voyager.kodein
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.screenModel.rememberNavigatorScreenModel
 import org.kodein.di.compose.localDI
 import org.kodein.di.direct
 import org.kodein.di.provider
@@ -21,4 +24,21 @@ public inline fun <reified A : Any, reified T : ScreenModel> Screen.rememberScre
     arg: A
 ): T = with(localDI()) {
     rememberScreenModel(tag = tag?.toString()) { direct.provider<A, T>(tag, arg)() }
+}
+
+@ExperimentalVoyagerApi
+@Composable
+public inline fun <reified T : ScreenModel> Navigator.rememberNavigatorScreenModel(
+    tag: Any? = null
+): T = with(localDI()) {
+    rememberNavigatorScreenModel(tag = tag?.toString()) { direct.provider<T>(tag)() }
+}
+
+@ExperimentalVoyagerApi
+@Composable
+public inline fun <reified A : Any, reified T : ScreenModel> Navigator.rememberNavigatorScreenModel(
+    tag: Any? = null,
+    arg: A
+): T = with(localDI()) {
+    rememberNavigatorScreenModel(tag = tag?.toString()) { direct.provider<A, T>(tag, arg)() }
 }

--- a/voyager-koin/build.gradle.kts
+++ b/voyager-koin/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(projects.voyagerCore)
+                api(projects.voyagerNavigator)
 
                 compileOnly(compose.runtime)
                 compileOnly(compose.runtimeSaveable)

--- a/voyager-koin/src/commonMain/kotlin/cafe/adriel/voyager/koin/ScreenModel.kt
+++ b/voyager-koin/src/commonMain/kotlin/cafe/adriel/voyager/koin/ScreenModel.kt
@@ -1,9 +1,12 @@
 package cafe.adriel.voyager.koin
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.screenModel.rememberNavigatorScreenModel
 import org.koin.compose.getKoin
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
@@ -15,4 +18,14 @@ public inline fun <reified T : ScreenModel> Screen.getScreenModel(
 ): T {
     val koin = getKoin()
     return rememberScreenModel(tag = qualifier?.value) { koin.get(qualifier, parameters) }
+}
+
+@ExperimentalVoyagerApi
+@Composable
+public inline fun <reified T : ScreenModel> Navigator.getNavigatorScreenModel(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null
+): T {
+    val koin = getKoin()
+    return rememberNavigatorScreenModel(tag = qualifier?.value) { koin.get(qualifier, parameters) }
 }

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
@@ -1,0 +1,36 @@
+package cafe.adriel.voyager.navigator.screenModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.remember
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import cafe.adriel.voyager.core.model.ScreenModel
+import cafe.adriel.voyager.core.model.ScreenModelStore
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import cafe.adriel.voyager.navigator.lifecycle.NavigatorDisposable
+import cafe.adriel.voyager.navigator.lifecycle.NavigatorLifecycleStore
+
+@Composable
+public inline fun <reified T : ScreenModel> Navigator.rememberNavigatorScreenModel(
+    tag: String? = null,
+    crossinline factory: @DisallowComposableCalls () -> T
+): T {
+    // register the navigator lifecycle listener if is not already registered
+    remember(this) {
+        NavigatorLifecycleStore.register(this) { NavigatorScreenModelDisposer }
+    }
+
+    return remember(ScreenModelStore.getKey<T>(this.key, tag)) {
+        ScreenModelStore.getOrPut(this.key, tag, factory)
+    }
+}
+
+@InternalVoyagerApi
+public object NavigatorScreenModelDisposer : NavigatorDisposable {
+    override fun onDispose(navigator: Navigator) {
+        ScreenModelStore.onDisposeNavigator(navigator.key)
+    }
+}

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
@@ -3,17 +3,16 @@ package cafe.adriel.voyager.navigator.screenModel
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.remember
+import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.ScreenModelStore
-import cafe.adriel.voyager.core.screen.Screen
-import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
-import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.lifecycle.NavigatorDisposable
 import cafe.adriel.voyager.navigator.lifecycle.NavigatorLifecycleStore
 
 @Composable
+@ExperimentalVoyagerApi
 public inline fun <reified T : ScreenModel> Navigator.rememberNavigatorScreenModel(
     tag: String? = null,
     crossinline factory: @DisallowComposableCalls () -> T

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/screenModel/NavigatorScreenModel.kt
@@ -11,8 +11,8 @@ import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.lifecycle.NavigatorDisposable
 import cafe.adriel.voyager.navigator.lifecycle.NavigatorLifecycleStore
 
-@Composable
 @ExperimentalVoyagerApi
+@Composable
 public inline fun <reified T : ScreenModel> Navigator.rememberNavigatorScreenModel(
     tag: String? = null,
     crossinline factory: @DisallowComposableCalls () -> T


### PR DESCRIPTION
Proposal API for `ScreenModel` scoped in Navigator.  This implementation follows the current ScreenModelStore implementation, and it supports on it for Navigator ScreenModel, the custom dependencies API works as expected as well for Navigator Scoped.

Usage:

```kotlin
val navigator = LocalNavigator.currentOrThrow
val screenModel = navigator.rememberNavigatorScreenModel { YourScreenModel() }
```

For Root Navigator
```kotlin
val navigator = LocalNavigator.currentOrThrow
val rootNavigator = remember(navigator) { navigator.root() }
val screenModel = rootNavigator.rememberNavigatorScreenModel { YourScreenModel() }

fun Navigator.root(): Navigator {
   return if(parent == null) this
   else parent!!.root()
}
```

https://github.com/adrielcafe/voyager/assets/29736164/dc19d34e-0273-430b-95b6-08a0f09a923b


TODO: Add support for the Dependency Injection extensions.