### PR TITLE
feat: platform dispatchers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ plugin-hilt = { module = "com.google.dagger:hilt-android-gradle-plugin", version
 plugin-multiplatform-compose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "plugin-multiplatform-compose" }
 
 leakCanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakCanary" }
-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kodein = { module = "org.kodein.di:kodein-di-framework-compose", version.ref = "kodein" }
 koin = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin-compose" }

--- a/samples/multiplatform/build.gradle.kts
+++ b/samples/multiplatform/build.gradle.kts
@@ -67,7 +67,7 @@ kotlin {
 
                 implementation(projects.voyagerCore)
                 implementation(projects.voyagerNavigator)
-                implementation(libs.coroutines)
+                implementation(libs.coroutines.core)
             }
         }
 

--- a/voyager-core/build.gradle.kts
+++ b/voyager-core/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
             dependencies {
                 compileOnly(compose.runtime)
                 compileOnly(compose.runtimeSaveable)
-                implementation(libs.coroutines)
+                implementation(libs.coroutines.core)
             }
         }
         val jvmTest by getting {

--- a/voyager-core/src/androidMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.android.kt
+++ b/voyager-core/src/androidMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.android.kt
@@ -1,0 +1,9 @@
+package cafe.adriel.voyager.core.concurrent
+
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InternalVoyagerApi
+public actual val PlatformMainDispatcher: CoroutineDispatcher
+    get() = Dispatchers.Main.immediate

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.kt
@@ -1,0 +1,7 @@
+package cafe.adriel.voyager.core.concurrent
+
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import kotlinx.coroutines.CoroutineDispatcher
+
+@InternalVoyagerApi
+public expect val PlatformMainDispatcher: CoroutineDispatcher

--- a/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModel.kt
+++ b/voyager-core/src/commonMain/kotlin/cafe/adriel/voyager/core/model/ScreenModel.kt
@@ -3,6 +3,7 @@ package cafe.adriel.voyager.core.model
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.remember
+import cafe.adriel.voyager.core.concurrent.PlatformMainDispatcher
 import cafe.adriel.voyager.core.lifecycle.ScreenLifecycleStore
 import cafe.adriel.voyager.core.screen.Screen
 import kotlinx.coroutines.CoroutineName
@@ -25,7 +26,7 @@ public val ScreenModel.screenModelScope: CoroutineScope
     get() = ScreenModelStore.getOrPutDependency(
         screenModel = this,
         name = "ScreenModelCoroutineScope",
-        factory = { key -> CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate + CoroutineName(key)) },
+        factory = { key -> CoroutineScope(SupervisorJob() + PlatformMainDispatcher + CoroutineName(key)) },
         onDispose = { scope -> scope.cancel() }
     )
 

--- a/voyager-core/src/desktopMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.desktop.kt
+++ b/voyager-core/src/desktopMain/kotlin/cafe/adriel/voyager/core/concurrent/PlatformDispatcher.desktop.kt
@@ -1,0 +1,9 @@
+package cafe.adriel.voyager.core.concurrent
+
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InternalVoyagerApi
+public actual val PlatformMainDispatcher: CoroutineDispatcher
+    get() = Dispatchers.Main.immediate

--- a/voyager-core/src/jsMain/kotlin/cafe.adriel.voyager.core/concurrent/PlatformDispatcher.js.kt
+++ b/voyager-core/src/jsMain/kotlin/cafe.adriel.voyager.core/concurrent/PlatformDispatcher.js.kt
@@ -1,0 +1,9 @@
+package cafe.adriel.voyager.core.concurrent
+
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InternalVoyagerApi
+public actual val PlatformMainDispatcher: CoroutineDispatcher
+    get() = Dispatchers.Default

--- a/voyager-core/src/nativeMain/kotlin/cafe.adriel.voyager.core/concurrent/PlatformDispatcher.native.kt
+++ b/voyager-core/src/nativeMain/kotlin/cafe.adriel.voyager.core/concurrent/PlatformDispatcher.native.kt
@@ -1,0 +1,9 @@
+package cafe.adriel.voyager.core.concurrent
+
+import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InternalVoyagerApi
+public actual val PlatformMainDispatcher: CoroutineDispatcher
+    get() = Dispatchers.Main.immediate

--- a/voyager-koin/build.gradle.kts
+++ b/voyager-koin/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
                 compileOnly(compose.runtime)
                 compileOnly(compose.runtimeSaveable)
 
-                implementation(libs.coroutines)
+                implementation(libs.coroutines.core)
             }
         }
     }


### PR DESCRIPTION
This adds ScreenModel `screenModelScope` Dispatcher per Platform.

Fixes: #240

Also document Desktop used: https://voyager.adriel.cafe/screenmodel/coroutines-integration#desktop-note