### PR TITLE
docs: Provide factory lambda when calling ScreenModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ class HomeScreen : Screen {
 
     @Composable
     override fun Content() {
-        val screenModel = rememberScreenModel<HomeScreenModel>()
+        val screenModel = rememberScreenModel { HomeScreenModel() }
         // ...
     }
 }

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/kodeinIntegration/KodeinScreen.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/kodeinIntegration/KodeinScreen.kt
@@ -19,7 +19,7 @@ class KodeinScreen : Screen {
 
     @Composable
     override fun Content() {
-        val screenModel = rememberScreenModel<KodeinScreenModel>()
+        val screenModel = rememberScreenModel { KodeinScreenModel() }
         val scopedDependency by localDI().on(ScreenContext(this)).instance<KodeinScopedDependencySample>()
 
         Column {


### PR DESCRIPTION
I get an error when calling ScreenModel without a factory lambda. To follow the instruction in the [doc](https://voyager.adriel.cafe/screenmodel) on ScreenModel, this PR updates the ScrenModel calls in README and the sample project to provide factory lambda.

[The overview page](https://voyager.adriel.cafe/) should also be changed if this change is applicable.