### PR TITLE
Change back handler behavior

### DIFF
--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
@@ -173,6 +173,11 @@ public class Navigator @InternalVoyagerApi constructor(
         }
     }
 
+    internal fun popRecursively() {
+        if (pop()) return
+        parent?.popRecursively()
+    }
+
     @InternalVoyagerApi
     public fun dispose(
         screen: Screen

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorBackHandler.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorBackHandler.kt
@@ -12,15 +12,21 @@ internal fun NavigatorBackHandler(
     navigator: Navigator,
     onBackPressed: OnBackPressed
 ) {
-    if (onBackPressed != null) {
+    if (onBackPressed == null) {
         BackHandler(
-            enabled = navigator.canPop || navigator.parent?.canPop ?: false,
+            enabled = navigator.size > 1,
+            onBack = navigator::popRecursively
+        )
+    } else {
+        // `navigator.size == 1` covers onBackPressed = { false } and empty stack
+        // because `navigator.canPop` always returns `true` when stack min size is 1
+        BackHandler(
+            enabled = (navigator.size == 1 && !onBackPressed(navigator.lastItem)) ||
+                    navigator.canPop ||
+                    navigator.parent?.canPop ?: false,
             onBack = {
-                if (onBackPressed(navigator.lastItem)) {
-                    if (navigator.pop().not()) {
-                        navigator.parent?.pop()
-                    }
-                }
+                if (onBackPressed(navigator.lastItem))
+                    navigator.popRecursively()
             }
         )
     }


### PR DESCRIPTION
Update back handler behavior to work according to docs

Fixes #154
Fixes #255

#### Current behavior
| Method | How it works |
|:-|:-|
| `onBackPressed = null` | ✅ **stack size = 0**: default platform behavior <br/>:x: **stack size > 0**: default platform behavior<br/>Should pop backstack instead.<br/>BackHandler is not being handled properly, app is being closed.
| `onBackPressed = { false }` | :x: **stack size = 0**: default platform behavior<br/>Back press being supplied means that the developer will take care of that.<br/>According to docs "return `false` won't pop the current screen" is not actually true</br>✅ **stack size > 0**: does nothing |
| `onBackPressed = { true }` | ✅ **stack size = 0**: default platform behavior<br/>✅ **stack size > 0**: pop |


#### New behavior
| Method | How it works |
|:-|:-|
| `onBackPressed = null` | ✅ **stack size = 0**: default platform behavior <br/>✅ **stack size > 0**: pop
| `onBackPressed = { false }` | ✅ **stack size = 0**: does nothing</br>✅ **stack size > 0**: does nothing |
| `onBackPressed = { true }` | ✅ **stack size = 0**: default platform behavior<br/>✅ **stack size > 0**: pop |

Tested using `sample:multiplatform`