### PR TITLE
Cleanup Hilt ViewModel extensions

### DIFF
--- a/voyager-hilt/api/voyager-hilt.api
+++ b/voyager-hilt/api/voyager-hilt.api
@@ -24,6 +24,13 @@ public abstract interface annotation class cafe/adriel/voyager/hilt/ScreenModelK
 	public abstract fun value ()Ljava/lang/Class;
 }
 
+public final class cafe/adriel/voyager/hilt/ViewModelKt {
+	public static final fun createVoyagerFactory (Landroidx/lifecycle/ViewModelStoreOwner;Landroid/content/Context;Landroidx/lifecycle/ViewModelProvider$Factory;)Landroidx/lifecycle/ViewModelProvider$Factory;
+	public static synthetic fun createVoyagerFactory$default (Landroidx/lifecycle/ViewModelStoreOwner;Landroid/content/Context;Landroidx/lifecycle/ViewModelProvider$Factory;ILjava/lang/Object;)Landroidx/lifecycle/ViewModelProvider$Factory;
+	public static final fun get (Landroidx/lifecycle/ViewModelStoreOwner;Ljava/lang/Class;Ljava/lang/String;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
+	public static synthetic fun get$default (Landroidx/lifecycle/ViewModelStoreOwner;Ljava/lang/Class;Ljava/lang/String;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;ILjava/lang/Object;)Landroidx/lifecycle/ViewModel;
+}
+
 public final class cafe/adriel/voyager/hilt/VoyagerHiltViewModelFactories {
 	public static final field $stable I
 	public static final field INSTANCE Lcafe/adriel/voyager/hilt/VoyagerHiltViewModelFactories;

--- a/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/ViewModel.kt
+++ b/voyager-hilt/src/main/java/cafe/adriel/voyager/hilt/ViewModel.kt
@@ -1,13 +1,15 @@
 package cafe.adriel.voyager.hilt
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.HasDefaultViewModelProviderFactory
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.screen.Screen
@@ -21,35 +23,22 @@ import dagger.hilt.android.lifecycle.withCreationCallback
  * will be cleared when activity is totally destroyed only.
  *
  * @param viewModelProviderFactory A custom factory commonly used with Assisted Injection
+ * @param tag To identify the [ViewModel]
+ * @param viewModelStoreOwner The scope that the [ViewModel] will be created in
  * @return A new instance of [ViewModel] or the existent instance in the [ViewModelStore]
  */
 @Composable
 public inline fun <reified T : ViewModel> Screen.getViewModel(
-    viewModelProviderFactory: ViewModelProvider.Factory? = null
-): T {
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+    viewModelProviderFactory: ViewModelProvider.Factory? = null,
+    tag: String? = null,
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     }
-    return remember(key1 = T::class) {
-        val hasDefaultViewModelProviderFactory = requireNotNull(lifecycleOwner as? HasDefaultViewModelProviderFactory) {
-            "$lifecycleOwner is not a androidx.lifecycle.HasDefaultViewModelProviderFactory"
-        }
-        val viewModelStore = requireNotNull(viewModelStoreOwner?.viewModelStore) {
-            "$viewModelStoreOwner is null or have a null viewModelStore"
-        }
-        val factory = VoyagerHiltViewModelFactories.getVoyagerFactory(
-            activity = context.componentActivity,
-            delegateFactory = viewModelProviderFactory
-                ?: hasDefaultViewModelProviderFactory.defaultViewModelProviderFactory
-        )
-        val provider = ViewModelProvider(
-            store = viewModelStore,
-            factory = factory,
-            defaultCreationExtras = hasDefaultViewModelProviderFactory.defaultViewModelCreationExtras
-        )
-        provider[T::class.java]
+): T {
+    val context = LocalContext.current
+    return remember(key1 = tag) {
+        val factory = viewModelStoreOwner.createVoyagerFactory(context.componentActivity, viewModelProviderFactory)
+        viewModelStoreOwner.get(T::class.java, tag, factory)
     }
 }
 
@@ -59,44 +48,74 @@ public inline fun <reified T : ViewModel> Screen.getViewModel(
  * There is compatibility with Activity ViewModelLifecycleOwner too but it must be avoided because your ViewModels
  * will be cleared when activity is totally destroyed only.
  *
- * @param viewModelProviderFactory A custom factory commonly used with Assisted Injection
+ * @param tag To identify the [ViewModel]
+ * @param viewModelStoreOwner The scope that the [ViewModel] will be created in
  * @param viewModelFactory A custom factory to assist with creation of ViewModels
  * @return A new instance of [ViewModel] or the existent instance in the [ViewModelStore]
  */
 @Composable
 @ExperimentalVoyagerApi
-public inline fun <reified VM : ViewModel, F> Screen.getViewModel(
-    viewModelProviderFactory: ViewModelProvider.Factory? = null,
-    noinline viewModelFactory: (F) -> VM
-): VM {
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+public inline fun <reified T : ViewModel, F> Screen.getViewModel(
+    tag: String? = null,
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    noinline viewModelFactory: (F) -> T
+): T {
+    val context = LocalContext.current
+    return remember(key1 = tag) {
+        val factory = viewModelStoreOwner.createVoyagerFactory(context.componentActivity)
+        viewModelStoreOwner.get(
+            T::class.java,
+            tag,
+            factory,
+            if (viewModelStoreOwner is HasDefaultViewModelProviderFactory) {
+                viewModelStoreOwner.defaultViewModelCreationExtras.withCreationCallback(viewModelFactory)
+            } else {
+                CreationExtras.Empty.withCreationCallback(viewModelFactory)
+            }
+        )
     }
-    return remember(key1 = VM::class) {
-        val hasDefaultViewModelProviderFactory = requireNotNull(lifecycleOwner as? HasDefaultViewModelProviderFactory) {
-            "$lifecycleOwner is not a androidx.lifecycle.HasDefaultViewModelProviderFactory"
-        }
-        val viewModelStore = requireNotNull(viewModelStoreOwner?.viewModelStore) {
-            "$viewModelStoreOwner is null or have a null viewModelStore"
-        }
+}
 
-        val creationExtras = hasDefaultViewModelProviderFactory.defaultViewModelCreationExtras
-            .withCreationCallback(viewModelFactory)
-
-        val factory = VoyagerHiltViewModelFactories.getVoyagerFactory(
+@PublishedApi
+internal fun ViewModelStoreOwner.createVoyagerFactory(
+    context: Context,
+    viewModelProviderFactory: ViewModelProvider.Factory? = null
+): ViewModelProvider.Factory? {
+    val factory = viewModelProviderFactory
+        ?: (this as? HasDefaultViewModelProviderFactory)?.defaultViewModelProviderFactory
+    return if (factory != null) {
+        VoyagerHiltViewModelFactories.getVoyagerFactory(
             activity = context.componentActivity,
-            delegateFactory = viewModelProviderFactory
-                ?: hasDefaultViewModelProviderFactory.defaultViewModelProviderFactory
+            delegateFactory = factory
         )
+    } else {
+        null
+    }
+}
 
-        val provider = ViewModelProvider(
-            store = viewModelStore,
-            factory = factory,
-            defaultCreationExtras = creationExtras
-        )
-
-        provider[VM::class.java]
+@PublishedApi
+internal fun <T : ViewModel> ViewModelStoreOwner.get(
+    javaClass: Class<T>,
+    key: String?,
+    viewModelProviderFactory: ViewModelProvider.Factory? = null,
+    creationExtras: CreationExtras = if (this is HasDefaultViewModelProviderFactory) {
+        this.defaultViewModelCreationExtras
+    } else {
+        CreationExtras.Empty
+    }
+): T {
+    val factory = viewModelProviderFactory
+        ?: (this as? HasDefaultViewModelProviderFactory)?.defaultViewModelProviderFactory
+    val provider = if (factory != null) {
+        ViewModelProvider(viewModelStore, factory, creationExtras)
+    } else {
+        ViewModelProvider(this)
+    }
+    return if (key != null) {
+        provider[key, javaClass]
+    } else {
+        provider[javaClass]
     }
 }


### PR DESCRIPTION
- Share code between getViewModel extension functions
- Add tag and viewModelStoreOwner as parameters to allow sharing ViewModels between Screens

Sharing ViewModels between screen example:
```kt
class AScreen : AndroidScreen() {

    @Composable
    override fun Content() {
        val navigator = LocalNavigator.currentOrThrow
        val viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner
        val viewModel = getViewModel<AViewModel, AViewModel.Factory>(viewModelStoreOwner = viewModelStoreOwner) { factory ->
            factory.create("World")
        }
        Column {
            Button(onClick = { navigator.push(OtherScreen(viewModelStoreOwner)) }) {
                Text(text = "Other")
            }
        }
        // More Code
    }
}

class OtherScreen : AndroidScreen() {

    @Composable
    override fun Content() {
        val viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner
        val viewModel = getViewModel<AViewModel>(viewModelStoreOwner = viewModelStoreOwner)
        // More Code
    }

}
```