### PR TITLE
Fix: BottomSheet closes when recomposing in iOS #330

### DIFF
--- a/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
+++ b/voyager-bottom-sheet-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/bottomSheet/BottomSheetNavigator.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.contentColorFor
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -59,15 +60,15 @@ public fun BottomSheetNavigator(
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
-        confirmValueChange = { state ->
-            if (state == ModalBottomSheetValue.Hidden) {
-                hideBottomSheet?.invoke()
-            }
-            true
-        },
         skipHalfExpanded = skipHalfExpanded,
         animationSpec = animationSpec
     )
+
+    LaunchedEffect(sheetState, sheetState.currentValue) {
+        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
+            hideBottomSheet?.invoke()
+        }
+    }
 
     Navigator(HiddenBottomSheetScreen, onBackPressed = null, key = key) { navigator ->
         val bottomSheetNavigator = remember(navigator, sheetState, coroutineScope) {


### PR DESCRIPTION
Issue details:
https://github.com/adrielcafe/voyager/issues/330
Affected Platform: iOS
Compose version: 1.6.0

It seems the culprit is `confirmValueChange` in `rememberModalBottomSheetState`, it's using `rememberSaveable` where `confirmValueChange` is used as a key. When this method changes in iOS somehow when you open keyboard or any other thing that causes recomposition, it recreates the sheet state, which hides the bottom sheet modal.

Removing `confirmValueChange` and using `LaunchedEffect` to observe `sheetState.currentValue` solves the issue.