### PR TITLE
dispose steps after transition

### DIFF
--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         </activity>
         <activity android:name=".stateStack.StateStackActivity"/>
         <activity android:name=".basicNavigation.BasicNavigationActivity"/>
-        <activity android:name=".tabNavigation.TabNavigationActivity"/>
+        <activity android:name=".disposeSample.DisposeWhenTransitionFinishedSampleActivity"/>
+        <activity android:name=".disposeSample.DisposeWhenStackChangedSampleActivity"/>
         <activity android:name=".nestedNavigation.NestedNavigationActivity"/>
         <activity android:name=".parcelableScreen.ParcelableActivity"/>
         <activity android:name=".screenModel.ScreenModelActivity"/>

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/SampleActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/SampleActivity.kt
@@ -22,6 +22,8 @@ import cafe.adriel.voyager.sample.androidLegacy.LegacyActivity
 import cafe.adriel.voyager.sample.androidViewModel.AndroidViewModelActivity
 import cafe.adriel.voyager.sample.basicNavigation.BasicNavigationActivity
 import cafe.adriel.voyager.sample.bottomSheetNavigation.BottomSheetNavigationActivity
+import cafe.adriel.voyager.sample.disposeSample.DisposeWhenStackChangedSampleActivity
+import cafe.adriel.voyager.sample.disposeSample.DisposeWhenTransitionFinishedSampleActivity
 import cafe.adriel.voyager.sample.hiltIntegration.HiltMainActivity
 import cafe.adriel.voyager.sample.kodeinIntegration.KodeinIntegrationActivity
 import cafe.adriel.voyager.sample.koinIntegration.KoinIntegrationActivity
@@ -53,6 +55,8 @@ class SampleActivity : ComponentActivity() {
             contentPadding = PaddingValues(24.dp)
         ) {
             item {
+                StartSampleButton<DisposeWhenTransitionFinishedSampleActivity>("DisposeWhenTransitionFinished")
+                StartSampleButton<DisposeWhenStackChangedSampleActivity>("DisposeWhenStackChanged")
                 StartSampleButton<StateStackActivity>("SnapshotStateStack")
                 StartSampleButton<BasicNavigationActivity>("Basic Navigation")
                 StartSampleButton<ParcelableActivity>("Basic Navigation with Parcelable")
@@ -78,7 +82,9 @@ class SampleActivity : ComponentActivity() {
 
         Button(
             onClick = { context.startActivity(Intent(this, T::class.java)) },
-            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
         ) {
             Text(text = text)
         }

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeSampleActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeSampleActivity.kt
@@ -1,0 +1,39 @@
+package cafe.adriel.voyager.sample.disposeSample
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.DisposeStepsBehavior
+import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.NavigatorDisposeBehavior
+import cafe.adriel.voyager.transitions.SlideTransition
+
+open class DisposeSampleActivity(
+    private val disposeStepsBehavior: DisposeStepsBehavior
+) : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            Content()
+        }
+    }
+
+    @Composable
+    fun Content() {
+        Navigator(
+            screen = SampleScreen(0),
+            disposeBehavior = NavigatorDisposeBehavior(
+                disposeStepsBehavior = disposeStepsBehavior
+            )
+        ) {
+            SlideTransition(
+                navigator = it,
+                animationSpec = tween(1000)
+            )
+        }
+    }
+}

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeWhenStackChangedSampleActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeWhenStackChangedSampleActivity.kt
@@ -1,0 +1,5 @@
+package cafe.adriel.voyager.sample.disposeSample
+
+import cafe.adriel.voyager.navigator.DisposeStepsBehavior
+
+class DisposeWhenStackChangedSampleActivity : DisposeSampleActivity(DisposeStepsBehavior.DisposeWhenStackChanged)

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeWhenTransitionFinishedSampleActivity.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/DisposeWhenTransitionFinishedSampleActivity.kt
@@ -1,0 +1,7 @@
+package cafe.adriel.voyager.sample.disposeSample
+
+import cafe.adriel.voyager.navigator.DisposeStepsBehavior
+
+class DisposeWhenTransitionFinishedSampleActivity : DisposeSampleActivity(
+    DisposeStepsBehavior.DisposeWhenTransitionFinished
+)

--- a/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/SampleScreen.kt
+++ b/samples/android/src/main/java/cafe/adriel/voyager/sample/disposeSample/SampleScreen.kt
@@ -1,0 +1,84 @@
+package cafe.adriel.voyager.sample.disposeSample
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class SampleScreenModel : ViewModel() {
+
+    init {
+        Log.d("SampleScreenModel", "start doing job")
+        viewModelScope.launch {
+            while (true) {
+                Log.d("SampleScreenModel", "Doing job")
+                delay(1000)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        Log.d("SampleScreenModel", "Disposed")
+    }
+}
+
+data class SampleScreen(
+    private val index: Int
+) : Screen {
+
+    override val key: ScreenKey = "SampleScreen$index"
+
+    @Composable
+    override fun Content() {
+        if (index == 1) {
+            viewModel(key = key) { SampleScreenModel() }
+        }
+
+        val navigator = LocalNavigator.currentOrThrow
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(text = "Screen $index")
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { navigator.push(SampleScreen(index = index + 1)) }
+            ) {
+                Text(text = "Next")
+            }
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { navigator.pop() }
+            ) {
+                Text(text = "Back")
+            }
+        }
+    }
+}

--- a/voyager-navigator/api/android/voyager-navigator.api
+++ b/voyager-navigator/api/android/voyager-navigator.api
@@ -7,6 +7,15 @@ public final class cafe/adriel/voyager/navigator/ComposableSingletons$NavigatorK
 	public final fun getLambda-2$voyager_navigator_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class cafe/adriel/voyager/navigator/DisposeStepsBehavior : java/lang/Enum {
+	public static final field DisposeWhenStackChanged Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static final field DisposeWhenTransitionFinished Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static final field None Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static fun values ()[Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+}
+
 public final class cafe/adriel/voyager/navigator/Navigator : cafe/adriel/voyager/core/stack/Stack {
 	public static final field $stable I
 	public fun clearEvent ()V
@@ -41,16 +50,17 @@ public final class cafe/adriel/voyager/navigator/Navigator : cafe/adriel/voyager
 
 public final class cafe/adriel/voyager/navigator/NavigatorDisposeBehavior {
 	public static final field $stable I
-	public fun <init> ()V
+	public fun <init> (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;)V
+	public synthetic fun <init> (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZ)V
 	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
-	public final fun component2 ()Z
-	public final fun copy (ZZ)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
-	public static synthetic fun copy$default (Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;ZZILjava/lang/Object;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
+	public final fun component2 ()Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public final fun copy (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
+	public static synthetic fun copy$default (Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;ILjava/lang/Object;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisposeNestedNavigators ()Z
-	public final fun getDisposeSteps ()Z
+	public final fun getDisposeStepsBehavior ()Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/voyager-navigator/api/desktop/voyager-navigator.api
+++ b/voyager-navigator/api/desktop/voyager-navigator.api
@@ -7,6 +7,15 @@ public final class cafe/adriel/voyager/navigator/ComposableSingletons$NavigatorK
 	public final fun getLambda-2$voyager_navigator ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class cafe/adriel/voyager/navigator/DisposeStepsBehavior : java/lang/Enum {
+	public static final field DisposeWhenStackChanged Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static final field DisposeWhenTransitionFinished Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static final field None Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public static fun values ()[Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+}
+
 public final class cafe/adriel/voyager/navigator/Navigator : cafe/adriel/voyager/core/stack/Stack {
 	public static final field $stable I
 	public fun clearEvent ()V
@@ -41,16 +50,17 @@ public final class cafe/adriel/voyager/navigator/Navigator : cafe/adriel/voyager
 
 public final class cafe/adriel/voyager/navigator/NavigatorDisposeBehavior {
 	public static final field $stable I
-	public fun <init> ()V
+	public fun <init> (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;)V
+	public synthetic fun <init> (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZ)V
 	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
-	public final fun component2 ()Z
-	public final fun copy (ZZ)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
-	public static synthetic fun copy$default (Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;ZZILjava/lang/Object;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
+	public final fun component2 ()Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
+	public final fun copy (ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
+	public static synthetic fun copy$default (Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;ZLcafe/adriel/voyager/navigator/DisposeStepsBehavior;ILjava/lang/Object;)Lcafe/adriel/voyager/navigator/NavigatorDisposeBehavior;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisposeNestedNavigators ()Z
-	public final fun getDisposeSteps ()Z
+	public final fun getDisposeStepsBehavior ()Lcafe/adriel/voyager/navigator/DisposeStepsBehavior;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/voyager-navigator/build.gradle.kts
+++ b/voyager-navigator/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(projects.voyagerCore)
+            implementation(libs.coroutines.core)
             compileOnly(compose.runtime)
             compileOnly(compose.runtimeSaveable)
         }

--- a/voyager-transitions/src/commonMain/kotlin/cafe/adriel/voyager/transitions/ScreenTransition.kt
+++ b/voyager-transitions/src/commonMain/kotlin/cafe/adriel/voyager/transitions/ScreenTransition.kt
@@ -6,12 +6,15 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.core.annotation.ExperimentalVoyagerApi
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.stack.StackEvent
+import cafe.adriel.voyager.navigator.LocalTransitionFinishedEvents
 import cafe.adriel.voyager.navigator.Navigator
 
 @ExperimentalVoyagerApi
@@ -77,6 +80,7 @@ public fun ScreenTransition(
     )
 }
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 public fun ScreenTransition(
     navigator: Navigator,
@@ -104,6 +108,10 @@ public fun ScreenTransition(
         },
         modifier = modifier
     ) { screen ->
+        if (this.transition.targetState == this.transition.currentState) {
+            val transitionFinishedEvents = LocalTransitionFinishedEvents.current
+            LaunchedEffect(Unit) { transitionFinishedEvents.trySend(Unit) }
+        }
         navigator.saveableState("transition", screen) {
             content(screen)
         }


### PR DESCRIPTION
ISSUE SOLVED: [106](https://github.com/adrielcafe/voyager/issues/106)

There is a problem. Let's take a look at the sample code.

If we set `disposeStepsBehavior = DisposeStepsBehavior.DisposeWhenStackChanged` in my sample, then when navigating to the `SampleScreen#1` and going back, ViewModel on the `SampleScreen#1` will be recreated because of transition and work will go on in it. 

Also there is another problem. Suppose we use `screenModel` instead of `viewModel`. If we navigate back from the `SampleScreen#1` and, without waiting for the transition to complete, navigate back to the `SampleScreen#1`, screenModel will be recreated, **I expect the screenModel to be destroyed only after the screen has become invisible to the user and disappeared from the stack**. 

upd.

So, i've created 2 sample activities: `DisposeWhenStackChangedSampleActivity`, `DisposeWhenTransitionFinishedSampleActivity`. 

- `DisposeWhenStackChangedSampleActivity`. Just open it, then click `Next`, on the next screen click `Back`. You can see in logcat, that `Doing job` is still printing. 
- `DisposeWhenTransitionFinishedSampleActivity`. Same steps, but everything works correctly