### PR TITLE
Added targetContentZIndex and sizeTransform value passthrough

### DIFF
--- a/voyager-transitions/src/commonMain/kotlin/cafe/adriel/voyager/transitions/ScreenTransition.kt
+++ b/voyager-transitions/src/commonMain/kotlin/cafe/adriel/voyager/transitions/ScreenTransition.kt
@@ -163,7 +163,12 @@ public fun ScreenTransition(
             val screenExitTransition = sourceScreenTransition?.exit(navigator.lastEvent)
                 ?: contentTransform.initialContentExit
 
-            screenEnterTransition togetherWith screenExitTransition
+            ContentTransform(
+                screenEnterTransition,
+                screenExitTransition,
+                contentTransform.targetContentZIndex,
+                contentTransform.sizeTransform,
+            )
         },
         modifier = modifier
     ) { screen ->


### PR DESCRIPTION
Fixes #444 
Added logic to pass the values of the supplied `contentTransform`s `targetContentZIndex` and `sizeTransform`