### PR TITLE
tab-navigator: Add more tab field for M3 bottom navigation

### DIFF
--- a/voyager-tab-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/tab/Tab.kt
+++ b/voyager-tab-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/tab/Tab.kt
@@ -17,7 +17,10 @@ public fun CurrentTab() {
 public data class TabOptions(
     val index: UShort,
     val title: String,
-    val icon: Painter? = null
+    val icon: Painter? = null,
+    val unselectedIcon: Painter? = null,
+    val hasNews: Boolean? = null,
+    val badgeCount: Int? = null
 )
 
 public interface Tab : Screen {


### PR DESCRIPTION
according to this https://www.youtube.com/watch?v=c8XP_Ee7iqY&t=685s

We have to create

```kotlin
data class BottomNavigationItem(
    val title: String,
    val selectedIcon: ImageVector,
    val unselectedIcon: ImageVector,
    val hasNews: Boolean,
    val badgeCount: Int? = null
)
```

so to support this we can add it. Although similar thing can be achieved with hashmap like this

```kotlin
data class CustomTabOptions (
    val title: String,
    val selectedIcon: ImageVector,
    val unselectedIcon: ImageVector,
    val hasNews: Boolean,
    val badgeCount: Int? = null
) {
    companion object {
        val customTabOptionsMap: HashMap<String, CustomTabOptions> = hashMapOf(
            "Home" to CustomTabOptions(
                title = "Home",
                selectedIcon = Icons.Filled.Home,
                unselectedIcon = Icons.Outlined.Home,
                hasNews = false
            ),
```