### PR TITLE
Update setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,10 +32,10 @@
         // Transitions
         implementation("cafe.adriel.voyager:voyager-transitions:$voyagerVersion")
         
-        // Android
-        
         // Koin integration
         implementation("cafe.adriel.voyager:voyager-koin:$voyagerVersion")
+        
+        // Android
         
         // Hilt integration
         implementation("cafe.adriel.voyager:voyager-hilt:$voyagerVersion")


### PR DESCRIPTION
The voyager-koin extension is wrongly placed under the **Android** section in the `setup.md` file.
It should be under multiplatform.