### PR TITLE
Replace providesDefault in Navigator with provides and an if check

### DIFF
--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/Navigator.kt
@@ -77,9 +77,7 @@ public fun Navigator(
     require(screens.isNotEmpty()) { "Navigator must have at least one screen" }
     require(key.isNotEmpty()) { "Navigator key can't be empty" }
 
-    CompositionLocalProvider(
-        LocalNavigatorStateHolder providesDefault rememberSaveableStateHolder()
-    ) {
+    ConditionalLocalNavigationStateHolderCompositionLocalProvider {
         val navigator = rememberNavigator(screens, key, disposeBehavior, LocalNavigator.current)
 
         if (navigator.parent?.disposeBehavior?.disposeNestedNavigators != false) {
@@ -190,3 +188,18 @@ public data class NavigatorDisposeBehavior(
 public fun compositionUniqueId(): String = currentCompositeKeyHash.toString(MaxSupportedRadix)
 
 private val MaxSupportedRadix = 36
+
+@Composable
+private fun ConditionalLocalNavigationStateHolderCompositionLocalProvider(content: @Composable () -> Unit) {
+    val navigatorStateHolder = LocalNavigatorStateHolder.current
+
+    if (navigatorStateHolder == null) {
+        CompositionLocalProvider(
+            LocalNavigatorStateHolder provides rememberSaveableStateHolder(),
+        ) {
+            content()
+        }
+    } else {
+        content()
+    }
+}

--- a/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorSaverInternal.kt
+++ b/voyager-navigator/src/commonMain/kotlin/cafe/adriel/voyager/navigator/internal/NavigatorSaverInternal.kt
@@ -11,8 +11,8 @@ import cafe.adriel.voyager.navigator.LocalNavigatorSaver
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.NavigatorDisposeBehavior
 
-internal val LocalNavigatorStateHolder: ProvidableCompositionLocal<SaveableStateHolder> =
-    staticCompositionLocalOf { error("LocalNavigatorStateHolder not initialized") }
+internal val LocalNavigatorStateHolder: ProvidableCompositionLocal<SaveableStateHolder?> =
+    staticCompositionLocalOf { null }
 
 @Composable
 internal fun rememberNavigator(
@@ -21,7 +21,7 @@ internal fun rememberNavigator(
     disposeBehavior: NavigatorDisposeBehavior,
     parent: Navigator?
 ): Navigator {
-    val stateHolder = LocalNavigatorStateHolder.current
+    val stateHolder = LocalNavigatorStateHolder.current ?: error("LocalNavigatorStateHolder not initialized")
     val navigatorSaver = LocalNavigatorSaver.current
     val saver = remember(navigatorSaver, stateHolder, parent, disposeBehavior) {
         navigatorSaver.saver(screens, key, stateHolder, disposeBehavior, parent)


### PR DESCRIPTION
This is a workaround for an [issue](https://youtrack.jetbrains.com/issue/CMP-6891/Nesting-providesDefault-for-a-LocalProvider-blocks-changes-from-other-LocalProviders-from-being-propagated-down-the-line.) with Compose Multiplatform which prevents theme and system padding updates from happening inside nested navigators.

Fixes https://github.com/adrielcafe/voyager/issues/484, https://github.com/adrielcafe/voyager/issues/486 and https://github.com/adrielcafe/voyager/issues/489.